### PR TITLE
Allow the copy of encrypted snapshots

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # rdscheck
 + Copy command will:
-    - Copy snapshot(s) to a different AWS region in the same account
+    - Copy snapshot(s) to a different AWS region in the same account. This will copy only automated snapshots.
     - Cleanup old snapshots based on retention setup in the yaml config file
 + Check command will:
     - Creates new rds instance(s) with the snapshots
@@ -20,6 +20,7 @@
     - password: `the password that we will use to connect to the database. It doesn't need to be the original one. We will use this one to reset the original password`
     - retention: `how many days we want to keep the copied snapshot around`
     - destination: `the aws region where we will copy/restore the snapshot`
+    - kmsid: `the id (ARN) of the kms key that you want to use on the destination region. This is needed if your original snapshot is encrypted`
     - queries: `all the sql queries we want to run on the restored snapshot to validate it and the expected results as regex`
       - query: `the sql query to run`
       - regex: `the regex of the expected result`
@@ -33,6 +34,7 @@ instances:
     password: thisisatest
     retention: 1
     destination: us-east-1
+    kmsid: "arn:aws:kms:us-east-1:1234567890:key/123456-7890-123456"
     queries:
       - query: "SELECT tablename FROM pg_catalog.pg_tables;"
         regex: "^pg_statistic$"

--- a/checks/commands_test.go
+++ b/checks/commands_test.go
@@ -89,11 +89,6 @@ func (m *mockRDS) CopyDBSnapshotRequest(input *rds.CopyDBSnapshotInput) (*reques
 	return args.Get(0).(*request.Request), args.Get(1).(*rds.CopyDBSnapshotOutput)
 }
 
-func (m *mockRDS) Presign(expire time.Duration) (string, error) {
-	args := m.Called(expire)
-	return args.Get(0).(string), args.Error(1)
-}
-
 func TestGetSnapshots(t *testing.T) {
 	rdsc := &mockRDS{}
 

--- a/checks/commands_test.go
+++ b/checks/commands_test.go
@@ -1,10 +1,13 @@
 package checks
 
 import (
+	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/service/rds"
 	"github.com/aws/aws-sdk-go/service/rds/rdsiface"
 	"github.com/stretchr/testify/assert"
@@ -81,6 +84,16 @@ func (m *mockRDS) ModifyDBInstance(input *rds.ModifyDBInstanceInput) (*rds.Modif
 	return args.Get(0).(*rds.ModifyDBInstanceOutput), args.Error(1)
 }
 
+func (m *mockRDS) CopyDBSnapshotRequest(input *rds.CopyDBSnapshotInput) (*request.Request, *rds.CopyDBSnapshotOutput) {
+	args := m.Called(input)
+	return args.Get(0).(*request.Request), args.Get(1).(*rds.CopyDBSnapshotOutput)
+}
+
+func (m *mockRDS) Presign(expire time.Duration) (string, error) {
+	args := m.Called(expire)
+	return args.Get(0).(string), args.Error(1)
+}
+
 func TestGetSnapshots(t *testing.T) {
 	rdsc := &mockRDS{}
 
@@ -109,7 +122,7 @@ func TestGetSnapshots(t *testing.T) {
 	rdsc.AssertExpectations(t)
 }
 
-func TestCopySnapshots(t *testing.T) {
+func TestCopySnapshotsNoKms(t *testing.T) {
 	rdsc := &mockRDS{}
 
 	c := &Client{
@@ -119,13 +132,38 @@ func TestCopySnapshots(t *testing.T) {
 	input := &rds.DBSnapshot{
 		DBSnapshotIdentifier: aws.String("test"),
 		DBSnapshotArn:        aws.String("arn:aws:rds:us-west-2:123456789012:snapshot:test"),
+		Encrypted:            aws.Bool(false),
 	}
 
 	rdsc.On("CopyDBSnapshot", mock.Anything).Return(&rds.CopyDBSnapshotOutput{
 		DBSnapshot: &rds.DBSnapshot{},
 	}, nil)
 
-	err := c.CopySnapshots(input, "us-west-2")
+	err := c.CopySnapshots(input, "us-west-2", "", "", "test")
+	assert.Nil(t, err)
+	rdsc.AssertExpectations(t)
+
+}
+
+func TestCopySnapshotsWithKms(t *testing.T) {
+	rdsc := &mockRDS{}
+
+	c := &Client{
+		RDS: rdsc,
+	}
+
+	input := &rds.DBSnapshot{
+		DBSnapshotIdentifier: aws.String("test"),
+		DBSnapshotArn:        aws.String("arn:aws:rds:us-west-2:123456789012:snapshot:test"),
+		KmsKeyId:             aws.String("arn:aws:kms:us-east-1:1234567890:key/123456-7890-123456"),
+		Encrypted:            aws.Bool(true),
+	}
+
+	rdsc.On("CopyDBSnapshot", mock.Anything).Return(&rds.CopyDBSnapshotOutput{
+		DBSnapshot: &rds.DBSnapshot{},
+	}, nil)
+
+	err := c.CopySnapshots(input, "us-west-2", "arn:aws:kms:us-east-1:1234567890:key/123456-7890-123456", "https://url.local", "test")
 	assert.Nil(t, err)
 	rdsc.AssertExpectations(t)
 
@@ -430,5 +468,34 @@ func TestGetTagValue(t *testing.T) {
 
 	value := c.GetTagValue("arn:aws:rds:us-west-2:123456789012:snapshot:test", "Status")
 	assert.Equal(t, value, "restore")
+	rdsc.AssertExpectations(t)
+}
+
+func TestPreSignUrl(t *testing.T) {
+	rdsc := &mockRDS{}
+
+	c := &Client{
+		RDS: rdsc,
+	}
+
+	u := &url.URL{
+		Scheme: "http",
+		Host:   "fakeurl.aws.com",
+	}
+
+	req := &request.Request{
+		HTTPRequest: &http.Request{
+			URL: u,
+		},
+		Operation: &request.Operation{},
+	}
+
+	output := &rds.CopyDBSnapshotOutput{}
+
+	rdsc.On("CopyDBSnapshotRequest", mock.Anything).Return(req, output)
+
+	value, err := c.PreSignUrl("us-east-2", "arn:aws:rds:us-west-2:123456789012:snapshot:test", "arn:aws:kms:us-east-1:1234567890:key/123456-7890-123456", "test")
+	assert.Nil(t, err)
+	assert.Equal(t, value, "http://fakeurl.aws.com")
 	rdsc.AssertExpectations(t)
 }

--- a/checks/common.go
+++ b/checks/common.go
@@ -24,7 +24,7 @@ type DefaultChecks interface {
 	GetYamlFileFromS3(bucket, key string) (io.Reader, error)
 	UnmarshalYamlFile(body io.Reader) (Doc, error)
 	DataDogSession(apiKey, applicationKey string) *datadog.Client
-	PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status string) error
+	PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status, cmdName string) error
 	GetSnapshots(DBInstanceIdentifier string) ([]*rds.DBSnapshot, error)
 	CopySnapshots(snapshot *rds.DBSnapshot, destination, kmsid, preSignedUrl, cleanArn string) error
 	GetOldSnapshots(snapshots []*rds.DBSnapshot, retention int) ([]*rds.DBSnapshot, error)
@@ -136,11 +136,12 @@ func (c *Client) UnmarshalYamlFile(body io.Reader) (Doc, error) {
 }
 
 // PostDatadogChecks posts to datadog the status of a check
-func (c *Client) PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status string) error {
+func (c *Client) PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status, cmdName string) error {
 
 	tags := []string{
 		"database:" + *snapshot.DBInstanceIdentifier,
 		"snapshot:" + *snapshot.DBSnapshotIdentifier,
+		"command" + cmdName,
 	}
 
 	timeNow := utils.GetUnixTimeAsString()

--- a/checks/common_test.go
+++ b/checks/common_test.go
@@ -117,7 +117,7 @@ func TestPostDatadogChecks(t *testing.T) {
 		DBSnapshotIdentifier: aws.String("test"),
 	}
 
-	err := c.PostDatadogChecks(input, "rdscheck.status", "ok")
+	err := c.PostDatadogChecks(input, "rdscheck.status", "ok", "check")
 	assert.Nil(t, err)
 }
 

--- a/checks/common_test.go
+++ b/checks/common_test.go
@@ -65,6 +65,7 @@ func TestUnmarshalYamlFile(t *testing.T) {
 				Password:    "thisisatest",
 				Retention:   1,
 				Destination: "us-east-1",
+				KmsID:       "arn:aws:kms:us-east-1:1234567890:key/123456-7890-123456",
 				Queries: []Queries{
 					Queries{
 						Query: "SELECT tablename FROM pg_catalog.pg_tables;",
@@ -118,4 +119,15 @@ func TestPostDatadogChecks(t *testing.T) {
 
 	err := c.PostDatadogChecks(input, "rdscheck.status", "ok")
 	assert.Nil(t, err)
+}
+
+func TestCleanArn(t *testing.T) {
+	c := &Client{}
+
+	input := &rds.DBSnapshot{
+		DBSnapshotArn: aws.String("arn:aws:rds:us-west-2:123456789012:snapshot:test"),
+	}
+
+	value := c.CleanArn(input)
+	assert.Equal(t, value, "test")
 }

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -215,26 +215,24 @@ func caseVerify(destination checks.DefaultChecks, snapshot *rds.DBSnapshot, inst
 		return err
 	}
 
-	if instance.Name == *dbInfo.DBName {
-		for _, query := range instance.Queries {
-			if destination.CheckRegexAgainstRow(query.Query, query.Regex) {
-				err := destination.UpdateTag(snapshot, "Status", "clean")
-				if err != nil {
-					return err
-				}
-			} else {
-				log.WithFields(log.Fields{
-					"RDS Instance": string(*snapshot.DBInstanceIdentifier + "-" + *snapshot.DBSnapshotIdentifier),
-					"DB Name":      *dbInfo.DBName,
-					"Query":        query.Query,
-					"Regex":        query.Regex,
-				}).Errorf("Query matched failed: %s", err)
-				errors := destination.UpdateTag(snapshot, "Status", "alarm")
-				if errors != nil {
-					return err
-				}
+	for _, query := range instance.Queries {
+		if destination.CheckRegexAgainstRow(query.Query, query.Regex) {
+			err := destination.UpdateTag(snapshot, "Status", "clean")
+			if err != nil {
 				return err
 			}
+		} else {
+			log.WithFields(log.Fields{
+				"RDS Instance": string(*snapshot.DBInstanceIdentifier + "-" + *snapshot.DBSnapshotIdentifier),
+				"DB Name":      *dbInfo.DBName,
+				"Query":        query.Query,
+				"Regex":        query.Regex,
+			}).Errorf("Query matched failed: %s", err)
+			errors := destination.UpdateTag(snapshot, "Status", "alarm")
+			if errors != nil {
+				return err
+			}
+			return err
 		}
 	}
 	return nil

--- a/cmd/check/main.go
+++ b/cmd/check/main.go
@@ -108,7 +108,7 @@ func process(destination checks.DefaultChecks, snapshot *rds.DBSnapshot, instanc
 }
 
 func caseReady(destination checks.DefaultChecks, snapshot *rds.DBSnapshot) error {
-	err := destination.PostDatadogChecks(snapshot, "rdscheck.status", "ok")
+	err := destination.PostDatadogChecks(snapshot, "rdscheck.status", "ok", "check")
 	if err != nil {
 		log.WithError(err).Error("Could not update datadog status")
 		return err
@@ -239,7 +239,7 @@ func caseVerify(destination checks.DefaultChecks, snapshot *rds.DBSnapshot, inst
 }
 
 func caseAlarm(destination checks.DefaultChecks, snapshot *rds.DBSnapshot) error {
-	err := destination.PostDatadogChecks(snapshot, "rdscheck.status", "critical")
+	err := destination.PostDatadogChecks(snapshot, "rdscheck.status", "critical", "check")
 	if err != nil {
 		log.WithError(err).Error("Could not update datadog status")
 		return err

--- a/cmd/check/main_test.go
+++ b/cmd/check/main_test.go
@@ -63,8 +63,8 @@ func (m *mockDefaultChecks) GetTagValue(arn, key string) string {
 	return args.Get(0).(string)
 }
 
-func (m *mockDefaultChecks) PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status string) error {
-	args := m.Called(snapshot, metricName, status)
+func (m *mockDefaultChecks) PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status, cmdName string) error {
+	args := m.Called(snapshot, metricName, status, cmdName)
 	return args.Error(0)
 }
 
@@ -169,7 +169,7 @@ func TestGetDoc(t *testing.T) {
 func TestCaseReady(t *testing.T) {
 	c := &mockDefaultChecks{}
 
-	c.On("PostDatadogChecks", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	c.On("PostDatadogChecks", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	c.On("CreateDatabaseSubnetGroup", mock.Anything, mock.Anything).Return(nil)
 	c.On("UpdateTag", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
@@ -223,7 +223,7 @@ func TestCaseVerify(t *testing.T) {
 func TestCaseAlarm(t *testing.T) {
 	c := &mockDefaultChecks{}
 
-	c.On("PostDatadogChecks", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	c.On("PostDatadogChecks", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	c.On("UpdateTag", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 
 	err := caseAlarm(c, singleSnapshot)

--- a/cmd/copy/main.go
+++ b/cmd/copy/main.go
@@ -63,7 +63,7 @@ func copy(source checks.DefaultChecks, destination checks.DefaultChecks) error {
 					if err != nil {
 						log.WithFields(log.Fields{
 							"snapshot": *snapshot.DBSnapshotIdentifier,
-						}).Errorf("Could not presigned the url: %s", err)
+						}).WithError(err).Error("Could not presigned the url")
 						err := destination.PostDatadogChecks(snapshot, "rdscheck.status", "critical", "copy")
 						if err != nil {
 							log.WithError(err).Error("Could not update datadog status")
@@ -76,7 +76,7 @@ func copy(source checks.DefaultChecks, destination checks.DefaultChecks) error {
 				if err != nil {
 					log.WithFields(log.Fields{
 						"Snapshot": *snapshot.DBSnapshotIdentifier,
-					}).Errorf("Could not copy snapshot: %s", err)
+					}).WithError(err).Error("Could not copy snapshot")
 					err := destination.PostDatadogChecks(snapshot, "rdscheck.status", "critical", "copy")
 					if err != nil {
 						log.WithError(err).Error("Could not update datadog status")

--- a/cmd/copy/main_test.go
+++ b/cmd/copy/main_test.go
@@ -41,17 +41,21 @@ var snapshots = []*rds.DBSnapshot{
 		DBSnapshotIdentifier: aws.String("test"),
 		SnapshotCreateTime:   aws.Time(time.Now().AddDate(0, 0, -10)),
 		DBSnapshotArn:        aws.String("arn:aws:rds:us-west-2:123456789012:snapshot:test"),
+		SnapshotType:         aws.String("automated"),
+		Encrypted:            aws.Bool(true),
 	},
 	&rds.DBSnapshot{
 		Status:               aws.String("available"),
 		DBSnapshotIdentifier: aws.String("test-2"),
 		SnapshotCreateTime:   aws.Time(time.Now()),
 		DBSnapshotArn:        aws.String("arn:aws:rds:us-west-2:123456789012:snapshot:test-2"),
+		SnapshotType:         aws.String("automated"),
+		Encrypted:            aws.Bool(true),
 	},
 }
 
-func (m *mockDefaultChecks) CopySnapshots(snapshot *rds.DBSnapshot, destination string) error {
-	args := m.Called(snapshot, destination)
+func (m *mockDefaultChecks) CopySnapshots(snapshot *rds.DBSnapshot, destination, kmsid, preSignedUrl, cleanArn string) error {
+	args := m.Called(snapshot, destination, kmsid)
 	return args.Error(0)
 }
 
@@ -84,6 +88,21 @@ func (m *mockDefaultChecks) UnmarshalYamlFile(body io.Reader) (checks.Doc, error
 	return args.Get(0).(checks.Doc), args.Error(1)
 }
 
+func (m *mockDefaultChecks) PreSignUrl(destinationRegion, snapshotArn, kmsid, cleanArn string) (string, error) {
+	args := m.Called(destinationRegion, snapshotArn, kmsid, cleanArn)
+	return args.Get(0).(string), args.Error(1)
+}
+
+func (m *mockDefaultChecks) CheckTag(arn string, key string, value string) bool {
+	args := m.Called(arn, key, value)
+	return args.Bool(0)
+}
+
+func (m *mockDefaultChecks) CleanArn(snapshot *rds.DBSnapshot) string {
+	args := m.Called(snapshot)
+	return args.Get(0).(string)
+}
+
 func TestCopy(t *testing.T) {
 	c := &mockDefaultChecks{}
 
@@ -94,7 +113,10 @@ func TestCopy(t *testing.T) {
 	c.On("GetYamlFileFromS3", mock.Anything, mock.Anything).Return(input, nil)
 	c.On("UnmarshalYamlFile", mock.Anything).Return(doc, nil)
 	c.On("GetSnapshots", mock.Anything).Return(snapshots, nil)
-	c.On("CopySnapshots", mock.Anything, mock.Anything).Return(nil)
+	c.On("CleanArn", mock.Anything).Return("test")
+	c.On("PreSignUrl", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://url.local", nil)
+	c.On("CopySnapshots", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	c.On("CheckTag", mock.Anything, mock.Anything, mock.Anything).Return(true)
 	c.On("GetOldSnapshots", mock.Anything, mock.Anything).Return(snapshots, nil)
 	c.On("DeleteOldSnapshots", mock.Anything).Return(nil)
 

--- a/cmd/copy/main_test.go
+++ b/cmd/copy/main_test.go
@@ -103,6 +103,11 @@ func (m *mockDefaultChecks) CleanArn(snapshot *rds.DBSnapshot) string {
 	return args.Get(0).(string)
 }
 
+func (m *mockDefaultChecks) PostDatadogChecks(snapshot *rds.DBSnapshot, metricName, status, cmdName string) error {
+	args := m.Called(snapshot, metricName, status, cmdName)
+	return args.Error(0)
+}
+
 func TestCopy(t *testing.T) {
 	c := &mockDefaultChecks{}
 
@@ -113,6 +118,7 @@ func TestCopy(t *testing.T) {
 	c.On("GetYamlFileFromS3", mock.Anything, mock.Anything).Return(input, nil)
 	c.On("UnmarshalYamlFile", mock.Anything).Return(doc, nil)
 	c.On("GetSnapshots", mock.Anything).Return(snapshots, nil)
+	c.On("PostDatadogChecks", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	c.On("CleanArn", mock.Anything).Return("test")
 	c.On("PreSignUrl", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return("https://url.local", nil)
 	c.On("CopySnapshots", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil)

--- a/example/checks.yml
+++ b/example/checks.yml
@@ -5,6 +5,7 @@ instances:
     password: thisisatest
     retention: 1
     destination: us-east-1
+    kmsid: "arn:aws:kms:us-east-1:1234567890:key/123456-7890-123456"
     queries:
       - query: "SELECT tablename FROM pg_catalog.pg_tables;"
         regex: "^pg_statistic$"

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -30,11 +30,10 @@ resource "null_resource" "get_release" {
 }
 
 data "archive_file" "lambda_code" {
-  type = "zip"
+  type        = "zip"
   source_file = "${path.module}/lambda-files/main"
   output_path = "${path.module}/lambda-files/main.zip"
-  
-  depends_on = ["null_resource.get_release"]
+  depends_on  = ["null_resource.get_release"]
 }
 
 resource "aws_lambda_function" "rdscheck_lambda" {


### PR DESCRIPTION
- We can now copy encrypted snapshots from a region to another by providing a kms key arn.
- If the snapshot is encrypted we generate a Presigned url and add it to the CopySnapshots function